### PR TITLE
Position Property

### DIFF
--- a/src/helpers/__tests__/position.js
+++ b/src/helpers/__tests__/position.js
@@ -1,0 +1,9 @@
+import position from "../position";
+
+it("sets the position to absolute", () => {
+  expect(position["absolute"].resolve()).toEqual({ position: "absolute" });
+});
+
+it("sets the position to relative", () => {
+  expect(position["relative"].resolve()).toEqual({ position: "relative" });
+});

--- a/src/helpers/position.js
+++ b/src/helpers/position.js
@@ -1,0 +1,12 @@
+import Style from "further";
+
+const position = {
+  absolute: Style(() => ({
+    position: "absolute",
+  })),
+  relative: Style(() => ({
+    position: "relative",
+  })),
+};
+
+export default position;


### PR DESCRIPTION
I tried to include a utility to define simple one-to-many relationships for properties. The position property is one example where you have, for react native, only two defined property options; `absolute` and `relative`.  I think it would be more helpful in the long run to have a utility that takes a property and a list of rule options. 